### PR TITLE
Size computation with channels

### DIFF
--- a/WavUtility.cs
+++ b/WavUtility.cs
@@ -204,7 +204,7 @@ public class WavUtility
 		//Debug.AssertFormat (bitDepth == 16, "Only converting 16 bit is currently supported. The audio clip data is {0} bit.", bitDepth);
 
 		// total file size = 44 bytes for header format and audioClip.samples * factor due to float to Int16 / sbyte conversion
-		int fileSize = audioClip.samples * BlockSize_16Bit + headerSize; // BlockSize (bitDepth)
+		int fileSize = audioClip.samples * BlockSize_16Bit * audioClip.channels + headerSize; // BlockSize (bitDepth)
 
 		// chunk descriptor (riff)
 		WriteFileHeader (ref stream, fileSize);
@@ -304,7 +304,7 @@ public class WavUtility
 		byte[] id = Encoding.ASCII.GetBytes ("data");
 		count += WriteBytesToMemoryStream (ref stream, id, "DATA_ID");
 
-		int subchunk2Size = Convert.ToInt32 (audioClip.samples * BlockSize_16Bit); // BlockSize (bitDepth)
+		int subchunk2Size = Convert.ToInt32 (audioClip.samples * BlockSize_16Bit * audioClip.channels); // BlockSize (bitDepth)
 		count += WriteBytesToMemoryStream (ref stream, BitConverter.GetBytes (subchunk2Size), "SAMPLES");
 
 		// Validate header


### PR DESCRIPTION
I found it needed to multiply channel count when computing size. Otherwise, the assert statement would give an error.